### PR TITLE
DDF-894 Added propertyIsNull support to the SolrFilterDelegate

### DIFF
--- a/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrFilterDelegate.java
+++ b/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrFilterDelegate.java
@@ -510,6 +510,31 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
         }
     }
 
+    /**
+     * This builds a "is null" query based on the property name provided.
+     *
+     * Since no type is provided with this method, we build a OR chained expression with anonymous field names.
+     * The actually expression uses a negative ranged query expression.  The null query needs to be used in order for this
+     * expression to play well with other nested expressions.  The query used is outlined in:
+     * http://stackoverflow.com/questions/17044661/how-to-filter-search-by-values-that-are-not-available/17045097#17045097
+     *
+     * @param propertyName the property to null check against.
+     * @return the solr query with the is null expression.
+     */
+    @Override
+    public SolrQuery propertyIsNull(String propertyName) {
+        List<String> possibleFields = resolver.getAnonymousField(propertyName);
+        if(possibleFields.isEmpty()){
+            throw new UnsupportedOperationException("Anonymous Field Property does not exist. " + propertyName);
+        }
+        List<String> solrExpressions = new ArrayList<>();
+        for (String possibleField : possibleFields) {
+            solrExpressions.add(" (*:* -" + possibleField + ":[* TO *]) ");
+        }
+        String fullExpression = StringUtils.join(solrExpressions, " ");
+        return new SolrQuery(fullExpression);
+    }
+
     private String geoPointToCircleQuery(String propertyName, double distanceInDegrees, Point pnt) {
         String circle = "Circle(" + pnt.getX() + " " + pnt.getY() + " d=" + distanceInDegrees + ")";
         String geoIndexName = getMappedPropertyName(propertyName, AttributeFormat.GEOMETRY, false);


### PR DESCRIPTION
-kind of odd to get this to work.  First you come in without a field type so we have to do so using the getAnonymousField() method.  Than we have to use the negative queries to actually get the results we need. (_:_ -fieldName:[\* TO *]) is the magic sause to get this to work.  For details on how this works, visit the url below.
-http://stackoverflow.com/questions/17044661/how-to-filter-search-by-values-that-are-not-available/17045097#17045097
