### PR TITLE
DDF-868 Default enabled source to the newly created configuration.

### DIFF
--- a/admin/module/catalog-admin-module-sources/Gruntfile.js
+++ b/admin/module/catalog-admin-module-sources/Gruntfile.js
@@ -58,7 +58,6 @@ module.exports = function (grunt) {
 
                 // Relaxing Options
                 scripturl: true,      // This option suppresses warnings about the use of script-targeted URLsâ€”such as
-                es5: true,             // Tells JSHint that your code uses ECMAScript 5 specific features such as getters and setters.
 
                 // options here to override JSHint defaults
                 globals: {

--- a/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Service.js
+++ b/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Service.js
@@ -13,6 +13,7 @@
  *
  **/
 /*global define*/
+/*jshint -W024*/
 define(function (require) {
 
     var Backbone = require('backbone'),

--- a/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
+++ b/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
@@ -117,7 +117,7 @@ define(function (require) {
         comparator: function(model) {
             var str = model.get('name') || '';
             return str.toLowerCase();
-        },
+        }
     });
 
     Source.Response = Backbone.Model.extend({


### PR DESCRIPTION
- New source configurations are automatically enabled rather than defaulting to a 'disabled' state
- Configuration save logic rewritten to wait for any disable (configuration) calls to finish before issuing a model refresh event.
