### PR TITLE
DDF-922 Add empty view for sources.

### DIFF
--- a/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/EmptyView.js
+++ b/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/EmptyView.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+        'text!templates/emptyView.handlebars',
+        'marionette',
+        'icanhaz'
+        ],function (emptyViewTemplate, Marionette, ich) {
+
+    ich.addTemplate('emptyViewTemplate', emptyViewTemplate);
+
+    var EmptyView = {};
+    
+    EmptyView.sources = Marionette.ItemView.extend({
+        template: 'emptyViewTemplate',
+        serializeData: function() {
+            return  {message: "There are no sources configured."};
+        }
+    });
+
+    return EmptyView;
+});

--- a/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
+++ b/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
@@ -20,6 +20,7 @@ define([
     'jquery',
     'q',
     'js/view/ModalSource.view.js',
+    'js/view/EmptyView.js',
     'js/model/Service.js',
     'wreqr',
     'text!templates/deleteModal.handlebars',
@@ -28,7 +29,7 @@ define([
     'text!templates/sourceList.handlebars',
     'text!templates/sourceRow.handlebars'
 ],
-function (ich,Marionette,_,$,Q,ModalSource,Service,wreqr,deleteModal,deleteSource,sourcePage,sourceList,sourceRow) {
+function (ich,Marionette,_,$,Q,ModalSource,EmptyView,Service,wreqr,deleteModal,deleteSource,sourcePage,sourceList,sourceRow) {
 
     var SourceView = {};
 
@@ -113,6 +114,7 @@ function (ich,Marionette,_,$,Q,ModalSource,Service,wreqr,deleteModal,deleteSourc
     SourceView.SourceTable = Marionette.CompositeView.extend({
         template: 'sourceList',
         itemView: SourceView.SourceRow,
+        emptyView: EmptyView.sources,
         itemViewContainer: 'tbody'
     });
 
@@ -136,7 +138,8 @@ function (ich,Marionette,_,$,Q,ModalSource,Service,wreqr,deleteModal,deleteSourc
             sourcesModal: '#sources-modal'
         },
         onRender: function() {
-            this.collectionRegion.show(new SourceView.SourceTable({ model: this.model, collection: this.model.get("collection") }));
+            var collection = this.model.get('collection');
+            this.collectionRegion.show(new SourceView.SourceTable({ model: this.model, collection: collection }));
         },
         refreshSources: function() {
             var view = this;

--- a/admin/module/catalog-admin-module-sources/src/main/webapp/less/styles.less
+++ b/admin/module/catalog-admin-module-sources/src/main/webapp/less/styles.less
@@ -99,3 +99,12 @@
   max-height: 400px;
   overflow-y: auto;
 }
+
+.no-results {
+  height: 100px;
+  display: table;
+  .message {
+    display: table-cell;
+    vertical-align: middle;
+  }
+}

--- a/admin/module/catalog-admin-module-sources/src/main/webapp/templates/emptyView.handlebars
+++ b/admin/module/catalog-admin-module-sources/src/main/webapp/templates/emptyView.handlebars
@@ -1,0 +1,18 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+ <div class="no-results">
+    <div class="message">
+        {{message}}
+    </div>
+</div>


### PR DESCRIPTION
- An empty view was added to display a message when no federated sources are configured in the application.
