### PR TITLE
DDF-1079: In the Catalog Federation Strategy dialog, it is necessary to disable ca...

### DIFF
--- a/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -108,6 +108,8 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
     private static final int DEFAULT_MAX_START_INDEX = 50000;
 
     private int maxStartIndex;
+    
+    private boolean queryResultCachingEnabled;
 
     // register one party for scheduled phase advancer
     private CacheCommitPhaser phaser = new CacheCommitPhaser(1);
@@ -139,6 +141,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
         this.preQuery = preQuery;
         this.postQuery = postQuery;
         this.maxStartIndex = DEFAULT_MAX_START_INDEX;
+        this.queryResultCachingEnabled = true;
         this.cache = cache;
         // phase advancer blocks waiting for next phase advance, delay 1 second between advances
         scheduler.scheduleWithFixedDelay(new PhaseAdvancer(phaser), 1, 1, TimeUnit.SECONDS);
@@ -369,19 +372,21 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
             final SourceResponse sourceResponse = source.query(new QueryRequestImpl(request.getQuery(),
                     request.getProperties()));
 
-            if (INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-                // block next phase
-                phaser.register();
-                // cache results
-                cache.create(getMetacards(sourceResponse.getResults()));
-                // unblock phase and wait for all other parties to unblock phase
-                phaser.awaitAdvance(phaser.arriveAndDeregister());
-            } else if (!NATIVE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-                cacheExecutorService.submit(new Runnable() {
-                    @Override public void run() {
-                        cache.create(getMetacards(sourceResponse.getResults()));
-                    }
-                });
+            if (queryResultCachingEnabled) {
+                if (INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
+                    // block next phase
+                    phaser.register();
+                    // cache results
+                    cache.create(getMetacards(sourceResponse.getResults()));
+                    // unblock phase and wait for all other parties to unblock phase
+                    phaser.awaitAdvance(phaser.arriveAndDeregister());
+                } else if (!NATIVE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
+                    cacheExecutorService.submit(new Runnable() {
+                        @Override public void run() {
+                            cache.create(getMetacards(sourceResponse.getResults()));
+                        }
+                    });
+                }
             }
 
             return sourceResponse;
@@ -460,6 +465,11 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
     public void setExpirationIntervalInMinutes(long expirationIntervalInMinutes) {
         cache.setExpirationIntervalInMinutes(expirationIntervalInMinutes);
+    }
+    
+    public void setQueryResultCachingEnabled(boolean queryResultCachingEnabled) {
+        logger.debug("Setting queryResultCachingEnabled = {}", queryResultCachingEnabled);
+        this.queryResultCachingEnabled = queryResultCachingEnabled;
     }
 
     protected Runnable createMonitor(final CompletionService<SourceResponse> completionService,

--- a/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -141,7 +141,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
         this.preQuery = preQuery;
         this.postQuery = postQuery;
         this.maxStartIndex = DEFAULT_MAX_START_INDEX;
-        this.queryResultCachingEnabled = true;
+        this.queryResultCachingEnabled = false;
         this.cache = cache;
         // phase advancer blocks waiting for next phase advance, delay 1 second between advances
         scheduler.scheduleWithFixedDelay(new PhaseAdvancer(phaser), 1, 1, TimeUnit.SECONDS);

--- a/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/sortedFederationStrategy.xml
+++ b/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/sortedFederationStrategy.xml
@@ -23,6 +23,9 @@
     <OCD description="Catalog Caching Federation Strategy"
          name="Catalog Federation Strategy"
          id="ddf.catalog.federation.impl.CachingFederationStrategy">
+        <AD name="Enable Caching of Query Results" id="queryResultCachingEnabled" required="true" type="Boolean"
+            default="true"
+            description="When enabled all unique query results are cached for faster retrieval for future queries with the same search criteria."/> 
         <AD name="Maximum start index" id="maxStartIndex" required="true" type="Integer"
             default="50000"
             description="Sets a limit on the number of results this sorted federation strategy can handle from each federated source. A large start index

--- a/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/sortedFederationStrategy.xml
+++ b/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/sortedFederationStrategy.xml
@@ -24,7 +24,7 @@
          name="Catalog Federation Strategy"
          id="ddf.catalog.federation.impl.CachingFederationStrategy">
         <AD name="Enable Caching of Query Results" id="queryResultCachingEnabled" required="true" type="Boolean"
-            default="true"
+            default="false"
             description="When enabled all unique query results are cached for faster retrieval for future queries with the same search criteria."/> 
         <AD name="Maximum start index" id="maxStartIndex" required="true" type="Integer"
             default="50000"
@@ -37,7 +37,7 @@
 
         <AD name="Expiration Interval" id="expirationIntervalInMinutes" required="true" type="Long"
             default="10080"
-            description="Solr Cache expiration interval in minutes."/>
+            description="Solr Cache expiration interval in minutes. Default of 7 days: 10080 minutes"/>
 
         <AD description="HTTP URL of Solr 4.x Server" name="Solr URL" id="url"
             required="true" type="String" default="https://localhost:8993/solr"/>


### PR DESCRIPTION
...ching of products as a workaround to the problem described in https://tools.codice.org/jira/browse/DDF-1029.

This solution involves reverting to the following changes:
https://github.com/codice/ddf-catalog/commit/873f7c74520fc097bf764a1e9554046de8904b71

In addition, more logic is required in the CachingFederationStrategy.java to guard against adding of records to the metacard cache when caching is disabled.

The ddf-ui SearchController.java class will also require an update to expect all results from a single 'index' mode in lieu of separately querying a 'cache' mode. When caching is enabled, all results are returned when querying 'index' mode.

These changes were tested using by reproducing the issue documented in DDF-1029 with caching enabled, and disabled. When disabled the problem documented in the DDF-1029 was not reproduced, but when enabled the problem was reproduced. The ability to use the existing catalog interfaces were also tested with caching enabled and disabled to ensure that the changes to the CachingFederationStrategy didn't introduce any errors. 