### PR TITLE
DDF-1194 Updating the error handling for ingesting

### DIFF
--- a/core/catalog-core-commands/pom.xml
+++ b/core/catalog-core-commands/pom.xml
@@ -67,6 +67,11 @@
         </dependency>
 
         <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>filter-proxy</artifactId>
             <scope>test</scope>

--- a/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -315,9 +315,7 @@ public class IngestCommand extends CatalogCommands {
 
     private void logIngestException(IngestException exception, File inputFile) {
         LOGGER.debug("Failed to ingest file [{}].", inputFile.getAbsolutePath(), exception);
-        if (INGEST_LOGGER.isWarnEnabled()) {
-            INGEST_LOGGER.warn("Failed to ingest file [{}]:  \n{}", inputFile.getAbsolutePath(), Exceptions.getFullMessage(exception));
-        }
+        INGEST_LOGGER.warn("Failed to ingest file [{}]:  \n{}", inputFile.getAbsolutePath(), Exceptions.getFullMessage(exception));
     }
 
     private CreateResponse createMetacards(CatalogFacade catalog, List<Metacard> listOfMetaCards)

--- a/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -29,6 +29,7 @@ import org.apache.felix.gogo.commands.Argument;
 import org.apache.felix.gogo.commands.Command;
 import org.apache.felix.gogo.commands.Option;
 import org.codice.ddf.commands.catalog.facade.CatalogFacade;
+import org.codice.ddf.platform.util.Exceptions;
 import org.joda.time.Period;
 import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
@@ -196,7 +197,13 @@ public class IngestCommand extends CatalogCommands {
                     elapsedTime, calculateRecordsPerSecond(ingestCount.get(), start, end));
             INGEST_LOGGER.info("{} file(s) ingested in {} [{} records/sec]", ingestCount.get(),
                     elapsedTime, calculateRecordsPerSecond(ingestCount.get(), start, end));
-            console.println();
+            if (INGEST_LOGGER.isWarnEnabled() && fileCount.get() != ingestCount.get()) {
+                console.println();
+                String failedAmount = Integer.toString(fileCount.get() - ingestCount.get());
+                printErrorMessage(failedAmount
+                        + " file(s) failed to be ingested.  See the ingest log for more details.");
+                INGEST_LOGGER.warn("{} files(s) failed to be ingested.", failedAmount);
+            }
 
             return null;
         } else if (inputFile.isFile()) {
@@ -208,6 +215,8 @@ public class IngestCommand extends CatalogCommands {
                 result = readMetacard(inputFile);
             } catch (IngestException e) {
                 result = null;
+                printErrorMessage("Failed to ingest file [" + inputFile.getAbsolutePath()
+                        + "].  See the ingest log for more details.");
                 logIngestException(e, inputFile);
                 if (failedIngestDirectory != null) {
                     moveToFailedIngestDirectory(inputFile);
@@ -305,10 +314,9 @@ public class IngestCommand extends CatalogCommands {
     }
 
     private void logIngestException(IngestException exception, File inputFile) {
-        printErrorMessage("Failed to ingest file [" + inputFile.getAbsolutePath() + "].");
-        printErrorMessage(exception.getMessage());
+        LOGGER.debug("Failed to ingest file [{}].", inputFile.getAbsolutePath(), exception);
         if (INGEST_LOGGER.isWarnEnabled()) {
-            INGEST_LOGGER.warn("Failed to ingest file [{}].", inputFile.getAbsolutePath(), exception);
+            INGEST_LOGGER.warn("\nFailed to ingest file [{}]:  \n" + Exceptions.getFullMessage(exception), inputFile.getAbsolutePath());
         }
     }
 

--- a/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -316,7 +316,7 @@ public class IngestCommand extends CatalogCommands {
     private void logIngestException(IngestException exception, File inputFile) {
         LOGGER.debug("Failed to ingest file [{}].", inputFile.getAbsolutePath(), exception);
         if (INGEST_LOGGER.isWarnEnabled()) {
-            INGEST_LOGGER.warn("\nFailed to ingest file [{}]:  \n" + Exceptions.getFullMessage(exception), inputFile.getAbsolutePath());
+            INGEST_LOGGER.warn("Failed to ingest file [{}]:  \n{}", inputFile.getAbsolutePath(), Exceptions.getFullMessage(exception));
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
                 <version>${ddf.platform.app.version}</version>
             </dependency>
             <dependency>
+                <groupId>ddf.platform</groupId>
+                <artifactId>platform-util</artifactId>
+                <version>${ddf.platform.app.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>ddf.catalog.transformer</groupId>
                 <artifactId>catalog-transformer-xml-binding</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
 - IngestCommand.java:
  - Added error handling for batch ingestion.  Previously we weren't commenting on files that failed to ingest.  Now the user will get notified if any of the files in the batch fail to ingest (how many, and where to find more details).
  - Updated logIngestException to only log the exception (previously we also printed).  The stack trace now gets directed to the debug log, while the message gets directed to the ingest log.
  - Updated error handling for single ingestion to print a message if the file fails to ingest (redirects the user to ingest log).  Previously this message was being printed in the logIngestException method, but that would cause the batch ingestion to print an error for every failed file (also, the method named implies it should only be logging).
 - catalog pom.xml:
  - Added dependency on ddf-platform-util.
 - catalog-core-commands pom.xml:
  - Added dependency on ddf-platform-util.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-catalog/83)
<!-- Reviewable:end -->
