### PR TITLE
DDF-1213 Improved query and caching performance under high load

### DIFF
--- a/core/catalog-core-standardframework/pom.xml
+++ b/core/catalog-core-standardframework/pom.xml
@@ -87,6 +87,10 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>ddf.catalog.core</groupId>
@@ -121,6 +125,12 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>2.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheBulkProcessor.java
+++ b/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheBulkProcessor.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+package ddf.catalog.cache.solr.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+
+/**
+ * Bulk adds metacards to the cache that are not needed immediately.
+ */
+class CacheBulkProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheBulkProcessor.class);
+
+    private final ScheduledExecutorService batchScheduler = Executors
+            .newSingleThreadScheduledExecutor();
+
+    private final Map<String, Metacard> metacardsToCache = new ConcurrentHashMap<>();
+
+    private long flushInterval = TimeUnit.SECONDS.toMillis(10);
+
+    private int maximumBacklogSize = 10000;
+
+    private int batchSize = 500;
+
+    private Date lastBulkAdd = new Date();
+
+    public CacheBulkProcessor(final SolrCache cache) {
+        this(cache, 1, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Create a new cache bulk processor that will check added metacards for bulk processing at
+     * the configured delay interval.
+     *
+     * @param cache target Solr cache to bulk add metacards
+     * @param delay delay between decision to bulk add
+     * @param delayUnit units of the delay
+     */
+    public CacheBulkProcessor(final SolrCache cache, final long delay,
+            final TimeUnit delayUnit) {
+        batchScheduler.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if (metacardsToCache.size() > 0 && (metacardsToCache.size() >= batchSize || timeToFlush())) {
+                        LOGGER.debug("{} metacards to batch add to cache", metacardsToCache.size());
+
+                        List<Metacard> metacards = new ArrayList<>(metacardsToCache.values());
+                        for (Collection<Metacard> batch : Lists.partition(metacards, batchSize)) {
+                            LOGGER.debug("Caching a batch of {} metacards", batch.size());
+                            cache.create(batch);
+
+                            for (Metacard metacard : batch) {
+                                metacardsToCache.remove(metacard.getId());
+                            }
+                        }
+
+                        lastBulkAdd = new Date();
+                    }
+                } catch (Throwable throwable) {
+                    LOGGER.warn("Scheduled bulk ingest to cache failed", throwable);
+                }
+            }
+        }, delay, delay, delayUnit);
+    }
+
+    private boolean timeToFlush() {
+        Date now = new Date();
+        return now.getTime() - lastBulkAdd.getTime() > flushInterval;
+    }
+
+    /**
+     * Adds metacards to be bulk added to cache.  Metacards will be ignored if backlog grows too
+     * large.  Metacard currently in backlog will be updated if added again.
+     *
+     * @param results metacards to add to current batch
+     */
+    public void add(final List<Result> results) {
+        if (metacardsToCache.size() < maximumBacklogSize) {
+            for (Result result : results) {
+                if (result != null) {
+                    Metacard metacard = result.getMetacard();
+                    if (metacard != null) {
+                        metacardsToCache.put(metacard.getId(), metacard);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Shutdown scheduled tasks.
+     */
+    public void shutdown() {
+        batchScheduler.shutdown();
+    }
+
+    int pendingMetacards() {
+        return metacardsToCache.size();
+    }
+
+    public void setFlushInterval(long flushInterval) {
+        this.flushInterval = flushInterval;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public void setMaximumBacklogSize(int maximumBacklogSize) {
+        this.maximumBacklogSize = maximumBacklogSize;
+    }
+}

--- a/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -14,6 +14,33 @@
  **/
 package ddf.catalog.cache.solr.impl;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.sort.SortBy;
+import org.opengis.filter.sort.SortOrder;
+import org.slf4j.LoggerFactory;
+import org.slf4j.ext.XLogger;
+
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.federation.FederationStrategy;
@@ -35,38 +62,11 @@ import ddf.catalog.plugin.PostFederatedQueryPlugin;
 import ddf.catalog.plugin.PostIngestPlugin;
 import ddf.catalog.plugin.PreFederatedQueryPlugin;
 import ddf.catalog.plugin.StopProcessingException;
-import ddf.catalog.source.IngestException;
 import ddf.catalog.source.Source;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.util.impl.DistanceResultComparator;
 import ddf.catalog.util.impl.RelevanceResultComparator;
 import ddf.catalog.util.impl.TemporalResultComparator;
-import org.opengis.filter.expression.PropertyName;
-import org.opengis.filter.sort.SortBy;
-import org.opengis.filter.sort.SortOrder;
-import org.slf4j.LoggerFactory;
-import org.slf4j.ext.XLogger;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.Phaser;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * This class represents a {@link ddf.catalog.federation.FederationStrategy} based on sorting {@link ddf.catalog.data.Metacard}s. The
@@ -101,7 +101,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
     private final SolrCache cache;
 
-    private ExecutorService cacheExecutorService = Executors.newCachedThreadPool();
+    private final ExecutorService cacheExecutorService = Executors.newFixedThreadPool(8);
 
     private ExecutorService queryExecutorService;
 
@@ -109,10 +109,11 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
     private int maxStartIndex;
 
-    // register one party for scheduled phase advancer
-    private CacheCommitPhaser phaser = new CacheCommitPhaser(1);
+    private CacheCommitPhaser cacheCommitPhaser = new CacheCommitPhaser();
 
-    private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private CacheBulkProcessor cacheBulkProcessor;
+
+    private boolean isCachingEverything = false;
 
     /**
      * The {@link List} of pre-federated query plugins to execute on the query request before the
@@ -140,8 +141,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
         this.postQuery = postQuery;
         this.maxStartIndex = DEFAULT_MAX_START_INDEX;
         this.cache = cache;
-        // phase advancer blocks waiting for next phase advance, delay 1 second between advances
-        scheduler.scheduleWithFixedDelay(new PhaseAdvancer(phaser), 1, 1, TimeUnit.SECONDS);
+        cacheBulkProcessor = new CacheBulkProcessor(cache);
     }
 
     @Override
@@ -366,22 +366,24 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
                     request.getProperties()));
 
             if (INDEX_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-                // block next phase
-                phaser.register();
-                // cache results
-                cache.create(getMetacards(sourceResponse.getResults()));
-                // unblock phase and wait for all other parties to unblock phase
-                phaser.awaitAdvance(phaser.arriveAndDeregister());
+                cacheCommitPhaser.add(sourceResponse.getResults());
             } else if (!NATIVE_QUERY_MODE.equals(request.getPropertyValue(QUERY_MODE))) {
-                cacheExecutorService.submit(new Runnable() {
-                    @Override public void run() {
-                        cache.create(getMetacards(sourceResponse.getResults()));
-                    }
-                });
+                if (isCachingEverything) {
+                    cacheExecutorService.submit(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                cacheBulkProcessor.add(sourceResponse.getResults());
+                            } catch (Throwable throwable) {
+                                logger.warn("Unable to add results for bulk processing", throwable);
+                            }
+                        }
+                    });
+                }
             }
 
             return sourceResponse;
-        };
+        }
     }
 
     private List<Metacard> getMetacards(List<Result> results) {
@@ -460,6 +462,10 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
     public void setExpirationAgeInMinutes(long expirationAgeInMinutes) {
         cache.setExpirationAgeInMinutes(expirationAgeInMinutes);
+    }
+
+    public void setCachingEverything(boolean cachingEverything) {
+        this.isCachingEverything = cachingEverything;
     }
 
     protected Runnable createMonitor(final CompletionService<SourceResponse> completionService,
@@ -622,25 +628,56 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
     }
 
-    // Phaser that forces all added documents to commit to the cache on phase advance
+    /**
+     * Phaser that forces all added metacards to commit to the cache on phase advance
+     */
     private class CacheCommitPhaser extends Phaser {
 
-        public CacheCommitPhaser(int parties) {
-            super(parties);
+        private final ScheduledExecutorService phaseScheduler = Executors
+                .newSingleThreadScheduledExecutor();
+
+        public CacheCommitPhaser() {
+            // There will always be at least one party which will be the PhaseAdvancer
+            super(1);
+
+            // PhaseAdvancer blocks waiting for next phase advance, delay 1 second between advances
+            // this is used to block queries that request to be indexed before continuing
+            // committing Solr more often than 1 second can cause performance issues and exceptions
+            phaseScheduler.scheduleWithFixedDelay(new PhaseAdvancer(this), 1, 1, TimeUnit.SECONDS);
         }
 
         @Override
         protected boolean onAdvance(int phase, int registeredParties) {
-            // registeredParties should be 1 since all parties other than the first
-            // will arriveAndDeregister when advancing
+            // registeredParties should be 1 since all parties other than the PhaseAdvancer
+            // will arriveAndDeregister in the add method
             cache.forceCommit();
 
             return super.onAdvance(phase, registeredParties);
         }
 
+        /**
+         * Adds results to cache and blocks for next phase advance
+         *
+         * @param results metacards to add to cache
+         */
+        public void add(List<Result> results) {
+            // block next phase
+            this.register();
+            // add results to cache
+            cache.create(getMetacards(results));
+            // unblock phase and wait for all other parties to unblock phase
+            this.awaitAdvance(this.arriveAndDeregister());
+        }
+
+        public void shutdown() {
+            this.forceTermination();
+            phaseScheduler.shutdown();
+        }
     }
 
-    // Runnable that makes one party arrive to a phaser on run
+    /**
+     * Runnable that makes one party arrive to a phaser on each run
+     */
     private static class PhaseAdvancer implements Runnable {
 
         private final Phaser phaser;
@@ -653,11 +690,12 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
         public void run() {
             phaser.arriveAndAwaitAdvance();
         }
+
     }
 
     public void shutdown() {
-        phaser.forceTermination();
-        scheduler.shutdown();
+        cacheCommitPhaser.shutdown();
+        cacheBulkProcessor.shutdown();
     }
 
 }

--- a/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
+++ b/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -102,7 +103,7 @@ public class SolrCache {
         return client.query(request);
     }
 
-    public void create(List<Metacard> metacards) {
+    public void create(Collection<Metacard> metacards) {
         if (metacards == null || metacards.size() == 0) {
             return;
         }

--- a/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/sortedFederationStrategy.xml
+++ b/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/sortedFederationStrategy.xml
@@ -42,6 +42,9 @@
 
         <AD description="HTTP URL of Solr 4.x Server" name="Solr URL" id="url"
             required="true" type="String" default="https://localhost:8993/solr"/>
+
+        <AD description="Cache all results unless configured as native" name="Cache Everything"
+            id="cachingEverything" required="true" type="Boolean" default="false"/>
     </OCD>
 
     <Designate pid="ddf.catalog.federation.impl.CachingFederationStrategy">

--- a/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CacheBulkProcessorTest.java
+++ b/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CacheBulkProcessorTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+package ddf.catalog.cache.solr.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyCollectionOf;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CacheBulkProcessorTest {
+
+    private CacheBulkProcessor cacheBulkProcessor;
+
+    @Mock
+    private SolrCache mockSolrCache;
+
+    @Captor
+    ArgumentCaptor<Collection<Metacard>> capturedMetacards;
+
+    @Before
+    public void setUp() throws Exception {
+        cacheBulkProcessor = new CacheBulkProcessor(mockSolrCache, 1, TimeUnit.MILLISECONDS);
+        cacheBulkProcessor.setBatchSize(10);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        cacheBulkProcessor.shutdown();
+    }
+
+    @Test
+    public void bulkAdd() throws Exception {
+        cacheBulkProcessor.setFlushInterval(TimeUnit.MINUTES.toMillis(1));
+        List<Result> mockResults = getMockResults(10);
+
+        cacheBulkProcessor.add(mockResults);
+        waitForPendingMetacardsToCache();
+
+        verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
+        assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
+    }
+
+    @Test
+    public void partialFlush() throws Exception {
+        cacheBulkProcessor.setFlushInterval(1);
+        List<Result> mockResults = getMockResults(1);
+
+        cacheBulkProcessor.add(mockResults);
+        waitForPendingMetacardsToCache();
+
+        verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
+        assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
+    }
+
+    @Test
+    public void nullResult() throws Exception {
+        cacheBulkProcessor.add(Collections.singletonList((Result) null));
+
+        verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+    }
+
+    @Test
+    public void nullMetacard() throws Exception {
+        Result mockResult = mock(Result.class);
+        when(mockResult.getMetacard()).thenReturn(null);
+
+        cacheBulkProcessor.add(Collections.singletonList(mockResult));
+
+        verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+    }
+
+    @Test
+    public void exceedsBacklog() throws Exception {
+        cacheBulkProcessor.setMaximumBacklogSize(0);
+        cacheBulkProcessor.add(getMockResults(10));
+
+        verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+    }
+
+    @Test
+    public void cacheThrowsExcpetion() throws Exception {
+        doThrow(new RuntimeException()).doNothing().when(mockSolrCache)
+                .create(anyCollectionOf(Metacard.class));
+        List<Result> mockResults = getMockResults(10);
+
+        cacheBulkProcessor.add(mockResults);
+        waitForPendingMetacardsToCache();
+
+        verify(mockSolrCache, atLeast(2)).create(capturedMetacards.capture());
+        for (Collection<Metacard> metacards : capturedMetacards.getAllValues()) {
+            assertThat(metacards).containsAll(getMetacards(mockResults));
+        }
+    }
+
+    @Test
+    public void updateMetacards() throws Exception {
+        cacheBulkProcessor.setFlushInterval(TimeUnit.MINUTES.toMillis(1));
+        List<Result> mockResults = getMockResults(10);
+        Collections.addAll(mockResults, mockResults.toArray(new Result[10]));
+
+        cacheBulkProcessor.add(mockResults);
+        waitForPendingMetacardsToCache();
+
+        verify(mockSolrCache).create(capturedMetacards.capture());
+        assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
+    }
+
+    private void waitForPendingMetacardsToCache() throws InterruptedException {
+        while (cacheBulkProcessor.pendingMetacards() > 0) {
+            Thread.sleep(2);
+        }
+    }
+
+    private Collection<Metacard> getMetacards(List<Result> results) {
+        List<Metacard> metacards = new ArrayList<>(results.size());
+
+        for (Result result : results) {
+            metacards.add(result.getMetacard());
+        }
+
+        return metacards;
+    }
+
+    private List<Result> getMockResults(int size) {
+        List<Result> results = new ArrayList<>(size);
+
+        for (int i = 0; i < size; i++) {
+            Metacard mockMetacard = mock(Metacard.class);
+            when(mockMetacard.getId()).thenReturn(Integer.toString(i));
+
+            Result mockResult = mock(Result.class);
+            when(mockResult.getMetacard()).thenReturn(mockMetacard);
+
+            results.add(mockResult);
+        }
+
+        return results;
+    }
+
+}

--- a/docs/src/main/resources/Extending.adoc
+++ b/docs/src/main/resources/Extending.adoc
@@ -4838,6 +4838,12 @@ Configuration -> Catalog Federation Strategy.
 |https://localhost:8993/solr
 |yes
 
+|cachingEverything
+|Boolean
+|Cache all results unless configured as native
+|false
+|yes
+
 |===
 
 [cols="2" options="header"]


### PR DESCRIPTION
- Made caching of non-cache mode queries optional and disabled it by
  default
- Switched to a fixed size thread pool
- Added batching to non-cache mode queries
- Refactored CacheCommitPhaser to encapsulate its implementation
  details to match CacheBatchAdder

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-catalog/86)
<!-- Reviewable:end -->
