### PR TITLE
DDF-1246 XStream + FJP solution with performance test

### DIFF
--- a/transformer/catalog-transformer-xml/pom.xml
+++ b/transformer/catalog-transformer-xml/pom.xml
@@ -65,6 +65,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>xmlunit</groupId>
             <artifactId>xmlunit</artifactId>
             <scope>test</scope>
@@ -91,7 +101,11 @@
                 <configuration>
                     <instructions>
                         <Embed-Dependency>
-                            ogc-tools-gml-jts,catalog-transformer-xml-binding,jaxb2-basics-runtime,gml-v_3_1_1-schema;inline=true
+                            guava,
+                            ogc-tools-gml-jts,
+                            catalog-transformer-xml-binding,
+                            jaxb2-basics-runtime,
+                            gml-v_3_1_1-schema;inline=true
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.name}</Bundle-Name>
@@ -151,6 +165,81 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.lazerycode.jmeter</groupId>
+                <artifactId>jmeter-maven-plugin</artifactId>
+                <version>1.10.1</version>
+                <configuration>
+                    <testResultsTimestamp>false</testResultsTimestamp>
+                    <overrideRootLogLevel>DEBUG</overrideRootLogLevel>
+                    <suppressJMeterOutput>false</suppressJMeterOutput>
+                    <ignoreResultFailures>true</ignoreResultFailures>
+
+                    <testFilesIncluded>
+                        <testFilesIncluded>XMLTransformerPerformance.jmx</testFilesIncluded>
+                    </testFilesIncluded>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>kg.apc</groupId>
+                        <artifactId>jmeter-plugins</artifactId>
+                        <version>1.0.0</version>
+                        <exclusions>
+                            <!--
+                               Unfortunately some transitive dependencies cannot be found on mvncentral
+                               and we have to explicitly exclude them.
+                               For a complete list, see https://github.com/mlex/jmeter-maven-example/
+                           -->
+                            <exclusion>
+                                <groupId>kg.apc</groupId>
+                                <artifactId>perfmon</artifactId>
+                            </exclusion>
+                            <!-- ... -->
+
+                            <!--
+                                Because of a bug in the jmeter-maven-plugin (see
+                                https://github.com/Ronnie76er/jmeter-maven-plugin/issues/77) we have to
+                                exclude jmeter dependencies here, too.
+                            -->
+                            <exclusion>
+                                <groupId>org.apache.jmeter</groupId>
+                                <artifactId>jorphan</artifactId>
+                            </exclusion>
+                            <!-- ... -->
+                        </exclusions>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>de.codecentric</groupId>
+                <artifactId>jmeter-graph-maven-plugin</artifactId>
+                <version>0.1.0</version>
+                <configuration>
+                    <inputFile>${project.build.directory}/jmeter/results/XMLTransformerPerformance.jtl</inputFile>
+                    <graphs>
+                        <!-- ... you can declare more <graph>-elements here -->
+                        <graph>
+                            <pluginType>BytesThroughputOverTime</pluginType>
+                            <width>800</width>
+                            <height>600</height>
+                            <outputFile>${project.build.directory}/jmeter/results/XMLTransformerPerformance2-bytes.png</outputFile>
+                        </graph>
+                        <graph>
+                            <pluginType>ThroughputVsThreads</pluginType>
+                            <width>800</width>
+                            <height>600</height>
+                            <outputFile>${project.build.directory}/jmeter/results/XMLTransformerPerformance2-thruvthreads.png</outputFile>
+                        </graph>
+                        <graph>
+                            <pluginType>TimesVsThreads</pluginType>
+                            <width>800</width>
+                            <height>600</height>
+                            <outputFile>${project.build.directory}/jmeter/results/XMLTransformerPerformance2-timevthreads.png</outputFile>
+                        </graph>
+
+                    </graphs>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/GeometryTransformer.java
+++ b/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/GeometryTransformer.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package ddf.catalog.transformer.xml;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import javax.activation.MimeType;
+import javax.activation.MimeTypeParseException;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.helpers.DefaultValidationEventHandler;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.impl.BinaryContentImpl;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transformer.xml.adapter.GeometryAdapter;
+
+/**
+ * Transforms Geometry object to BinaryContent
+ */
+class GeometryTransformer extends AbstractXmlTransformer {
+    private static final int BUFFER_SIZE = 512;
+
+    BinaryContent transform(Attribute attribute) throws CatalogTransformerException {
+        BinaryContent transformedContent = null;
+
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread()
+                    .setContextClassLoader(getClass().getClassLoader());
+
+            ByteArrayOutputStream os = new ByteArrayOutputStream(BUFFER_SIZE);
+
+            Marshaller marshaller = CONTEXT.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+            marshaller.setEventHandler(new DefaultValidationEventHandler());
+
+            try {
+                marshaller.marshal(GeometryAdapter.marshalFrom(attribute), os);
+            } catch (RuntimeException e) {
+                throw new CatalogTransformerException("Failed to marshall geometry data", e);
+            }
+            ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
+            transformedContent = new BinaryContentImpl(bais, new MimeType(TEXT_XML));
+        } catch (JAXBException e) {
+            throw new CatalogTransformerException("Failed JAXB Transformation", e);
+        } catch (MimeTypeParseException e) {
+            throw new CatalogTransformerException(
+                    "Failed Transformation with MimeType Parsing error", e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(tccl);
+        }
+
+        return transformedContent;
+    }
+}

--- a/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/GeometryTransformer.java
+++ b/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/GeometryTransformer.java
@@ -35,18 +35,17 @@ import ddf.catalog.transformer.xml.adapter.GeometryAdapter;
 class GeometryTransformer extends AbstractXmlTransformer {
     private static final int BUFFER_SIZE = 512;
 
-    BinaryContent transform(Attribute attribute) throws CatalogTransformerException {
+    static BinaryContent transform(Attribute attribute) throws CatalogTransformerException {
         BinaryContent transformedContent = null;
 
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread()
-                    .setContextClassLoader(getClass().getClassLoader());
+                    .setContextClassLoader(GeometryTransformer.class.getClassLoader());
 
             ByteArrayOutputStream os = new ByteArrayOutputStream(BUFFER_SIZE);
 
             Marshaller marshaller = CONTEXT.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             marshaller.setEventHandler(new DefaultValidationEventHandler());
 
             try {

--- a/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/XmlResponseQueueTransformer.java
+++ b/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/XmlResponseQueueTransformer.java
@@ -10,41 +10,353 @@
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- */
+ **/
 package ddf.catalog.transformer.xml;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Date;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RecursiveTask;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.activation.MimeType;
 import javax.activation.MimeTypeParseException;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.helpers.DefaultValidationEventHandler;
 
+import org.apache.commons.lang.time.DateFormatUtils;
+import org.apache.xerces.impl.dv.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.thoughtworks.xstream.converters.ConversionException;
+import com.thoughtworks.xstream.core.util.QuickWriter;
+import com.thoughtworks.xstream.io.copy.HierarchicalStreamCopier;
+import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
+import com.thoughtworks.xstream.io.xml.XppReader;
+import com.thoughtworks.xstream.io.xml.xppdom.XppFactory;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.AttributeType.AttributeFormat;
 import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.BinaryContentImpl;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.QueryResponseTransformer;
-import ddf.catalog.transformer.xml.adapter.AdaptedSourceResponse;
 
 /**
  * Transforms a {@link SourceResponse} object into Metacard Element XML text, which is GML 3.1.1.
  * compliant XML.
- *
  */
 public class XmlResponseQueueTransformer extends AbstractXmlTransformer
         implements QueryResponseTransformer {
+    public static final int BUFFER_SIZE = 1024;
+
+    /**
+     * Writer is not thread-safe; instances should not be shared.
+     */
+    // @NotThreadSafe
+    private static class MetacardPrintWriter extends PrettyPrintWriter {
+        private static final char[] NULL = "&#x0;".toCharArray();
+
+        private static final char[] AMP = "&amp;".toCharArray();
+
+        private static final char[] LT = "&lt;".toCharArray();
+
+        private static final char[] GT = "&gt;".toCharArray();
+
+        private static final char[] CR = "&#xd;".toCharArray();
+
+        private static final char[] APOS = "&apos;".toCharArray();
+
+        private boolean isRawText = false;
+
+        public MetacardPrintWriter(Writer writer) {
+            super(writer);
+        }
+
+        private void setRawValue(String text) {
+            try {
+                isRawText = true;
+                setValue(text);
+            } finally {
+                isRawText = false;
+            }
+        }
+
+        @Override
+        protected void writeText(QuickWriter writer, String text) {
+            if (text == null) {
+                return;
+            }
+
+            if (isRawText) {
+                writer.write(text);
+            } else {
+                int length = text.length();
+                for (int i = 0; i < length; i++) {
+                    char c = text.charAt(i);
+                    switch (c) {
+                    case '\0':
+                        writer.write(NULL);
+                        break;
+                    case '&':
+                        writer.write(AMP);
+                        break;
+                    case '<':
+                        writer.write(LT);
+                        break;
+                    case '>':
+                        writer.write(GT);
+                        break;
+                    case '\'':
+                        writer.write(APOS);
+                        break;
+                    case '\r':
+                        writer.write(CR);
+                        break;
+                    case '\t':
+                    case '\n':
+                        writer.write(c);
+                        break;
+                    default:
+                        if (Character.isDefined(c) && !Character.isISOControl(c)) {
+                            writer.write(c);
+                        } else {
+                            writer.write("&#x");
+                            writer.write(Integer.toHexString(c));
+                            writer.write(';');
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static class MetacardForkTask extends RecursiveTask<StringWriter> {
+        private static final String DF_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
+        private final ImmutableList<Result> resultList;
+
+        private final ForkJoinPool fjp;
+
+        private final int threshold;
+
+        private final AtomicBoolean cancelOperation;
+
+        MetacardForkTask(ImmutableList<Result> resultList, ForkJoinPool fjp, int threshold) {
+            this(resultList, fjp, threshold, new AtomicBoolean(false));
+        }
+
+        private MetacardForkTask(ImmutableList<Result> resultList, ForkJoinPool fjp, int threshold,
+                AtomicBoolean cancelOperation) {
+            this.resultList = resultList;
+            this.fjp = fjp;
+            this.threshold = threshold;
+            this.cancelOperation = cancelOperation;
+        }
+
+        @Override
+        protected StringWriter compute() {
+            if (cancelOperation.get()) {
+                return null;
+            }
+
+            if (resultList.size() < threshold) {
+                return doCompute();
+            } else {
+                int half = resultList.size() / 2;
+
+                MetacardForkTask fLeft = new MetacardForkTask(resultList.subList(0, half), fjp,
+                        threshold, cancelOperation);
+                fLeft.fork();
+                MetacardForkTask fRight = new MetacardForkTask(
+                        resultList.subList(half, resultList.size()), fjp, threshold,
+                        cancelOperation);
+                StringWriter rightList = fRight.compute();
+                StringWriter leftList = fLeft.join();
+
+                leftList.append(rightList.getBuffer());
+                return leftList;
+            }
+        }
+
+        private StringWriter doCompute() {
+            StringWriter stringWriter = new StringWriter(BUFFER_SIZE);
+            MetacardPrintWriter writer = new MetacardPrintWriter(stringWriter);
+
+            for (Result result : resultList) {
+                Metacard metacard = result.getMetacard();
+                writer.startNode("metacard");
+                if (metacard.getId() != null) {
+                    writer.addAttribute("ns1:id", metacard.getId());
+                }
+
+                writer.startNode("type");
+                if (metacard.getMetacardType().getName() == null
+                        || metacard.getMetacardType().getName().length() == 0) {
+                    writer.setValue(MetacardType.DEFAULT_METACARD_TYPE_NAME);
+                } else {
+                    writer.setValue(metacard.getMetacardType().getName());
+                }
+                writer.endNode(); // type
+
+                if (metacard.getSourceId() != null && metacard.getSourceId().length() > 0) {
+                    writer.startNode("source");
+                    writer.setValue(metacard.getSourceId());
+                    writer.endNode(); // source
+                }
+
+                Set<AttributeDescriptor> attributeDescriptors = metacard.getMetacardType()
+                        .getAttributeDescriptors();
+                for (AttributeDescriptor attributeDescriptor : attributeDescriptors) {
+                    String attributeName = attributeDescriptor.getName();
+                    if (attributeName.equals("id")) {
+                        continue;
+                    }
+
+                    Attribute attribute = metacard.getAttribute(attributeName);
+
+                    if (attribute != null) {
+                        AttributeFormat format = attributeDescriptor.getType().getAttributeFormat();
+                        try {
+                            writeAttributeToXml(writer, attribute, format);
+                        } catch (CatalogTransformerException | IOException e) {
+                            cancelOperation.set(true);
+                            throw new RuntimeException("Failure to write node; operation aborted",
+                                    e);
+                        }
+                    }
+                }
+                writer.endNode(); // metacard
+            }
+            writer.flush();
+            return stringWriter;
+        }
+
+        private void writeAttributeToXml(MetacardPrintWriter writer, Attribute attribute,
+                AttributeFormat format) throws IOException, CatalogTransformerException {
+            String attributeName = attribute.getName();
+
+            for (Serializable value : attribute.getValues()) {
+                String xmlValue = null;
+
+                switch (format) {
+
+                case STRING:
+                case BOOLEAN:
+                case SHORT:
+                case INTEGER:
+                case LONG:
+                case FLOAT:
+                case DOUBLE:
+                    xmlValue = value.toString();
+                    break;
+                case DATE:
+                    Date date = (Date) value;
+                    xmlValue = DateFormatUtils.formatUTC(date, DF_PATTERN);
+                    break;
+                case GEOMETRY:
+                    xmlValue = geoToXml(new GeometryTransformer().transform(attribute));
+                    break;
+                case OBJECT:
+                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                    try (ObjectOutput output = new ObjectOutputStream(bos)) {
+                        output.writeObject(attribute.getValue());
+                        xmlValue = Base64.encode(bos.toByteArray());
+                    }
+                    break;
+                case BINARY:
+                    xmlValue = Base64.encode((byte[]) value);
+                    break;
+                case XML:
+                    xmlValue = value.toString().replaceAll("[<][?]xml.*[?][>]", "");
+                    break;
+                }
+
+                // Write the node if we were able to convert it.
+                if (xmlValue != null) {
+                    writer.startNode(TYPE_NAME_LOOKUP.get(format));
+                    writer.addAttribute("name", attributeName);
+                    writer.startNode("value");
+
+                    if (format == AttributeFormat.XML || format == AttributeFormat.GEOMETRY) {
+                        writer.setRawValue(xmlValue);
+                    } else {
+                        writer.setValue(xmlValue);
+                    }
+
+                    writer.endNode(); // value
+                    writer.endNode(); // type
+                }
+            }
+        }
+
+        private String geoToXml(BinaryContent content) {
+            try {
+                XmlPullParser parser = XppFactory.createDefaultParser();
+                XppReader source = new XppReader(new InputStreamReader(content.getInputStream()),
+                        parser);
+
+                // Skip the first two nodes, the root nodes of the ns3: namespace
+                source.moveDown();
+                source.moveDown();
+
+                StringWriter stringWriter = new StringWriter(BUFFER_SIZE);
+                PrettyPrintWriter destination = new PrettyPrintWriter(stringWriter);
+
+                new HierarchicalStreamCopier().copy(source, destination);
+
+                // Ideally, we would not intermittently get different namespace prefixes from
+                // marshalling; however, we are and can't safely use a NamespacePrefixMapper.
+                // So we have this. We specifically look for the 'ns1' prefix which this
+                // transformer has locked to the http://www.opengis.net/gml URI. If we do not
+                // find it, we do a regex replace of the 'ns?' prefix we do find.
+                String geoNode = stringWriter.toString();
+                if (!geoNode.startsWith("<ns1:")) {
+                    geoNode = geoNode.replaceAll("([</])ns\\d:", "$1ns1:");
+                }
+
+                return geoNode;
+            } catch (XmlPullParserException e) {
+                throw new ConversionException("Unable to copy metadata to XML Output.", e);
+            }
+        }
+    }
+
+    private final ForkJoinPool fjp;
+
+    private int threshold;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(XmlResponseQueueTransformer.class);
 
     public static final MimeType MIME_TYPE = new MimeType();
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(XmlResponseQueueTransformer.class);
+    /**
+     * This lookup map is...unfortunate. The current JAXB, which will remain in use for many
+     * contexts until/unless we refactor and rewrite all XML processing, determines the attribute
+     * names from the metacard schema. This lookup map provides an ugly shortcut for our purposes.
+     */
+    private static final Map<AttributeType.AttributeFormat, String> TYPE_NAME_LOOKUP;
+
+    private static final Map<String, String> NAMESPACE_MAP;
 
     static {
         try {
@@ -54,52 +366,80 @@ public class XmlResponseQueueTransformer extends AbstractXmlTransformer
             LOGGER.info("Failure creating MIME type", e);
             throw new ExceptionInInitializerError(e);
         }
+
+        TYPE_NAME_LOOKUP = new ImmutableMap.Builder<AttributeType.AttributeFormat, String>()
+                .put(AttributeFormat.BINARY, "base64Binary").put(AttributeFormat.STRING, "string")
+                .put(AttributeFormat.BOOLEAN, "boolean").put(AttributeFormat.DATE, "dateTime")
+                .put(AttributeFormat.DOUBLE, "double").put(AttributeFormat.SHORT, "short")
+                .put(AttributeFormat.INTEGER, "int").put(AttributeFormat.LONG, "long")
+                .put(AttributeFormat.FLOAT, "float").put(AttributeFormat.GEOMETRY, "geometry")
+                .put(AttributeFormat.XML, "stringxml").put(AttributeFormat.OBJECT, "object")
+                .build();
+
+        String nsPrefix = "xmlns";
+
+        NAMESPACE_MAP = new ImmutableMap.Builder<String, String>()
+                .put(nsPrefix, "urn:catalog:metacard")
+                .put(nsPrefix + ":ns" + 1, "http://www.opengis.net/gml")
+                .put(nsPrefix + ":ns" + 2, "http://www.w3.org/1999/xlink")
+                .put(nsPrefix + ":ns" + 4, "http://www.w3.org/2001/SMIL20/")
+                .put(nsPrefix + ":ns" + 5, "http://www.w3.org/2001/SMIL20/Language").build();
+    }
+
+    /**
+     * Constructs a transformer that will convert query responses to XML.
+     * The {@code ForkJoinPool} is used for splitting large collections of {@link Metacard}s
+     * into smaller collections for concurrent processing. Currently injected through Blueprint,
+     * if we choose to use fork-join for other tasks in the application, we should move the
+     * construction of the pool from its current location. Conversely, if we move to Java 8 we
+     * can simply use the new {@code commonPool} static method provided on {@code ForkJoinPool}.
+     *
+     * @param fjp the {@code ForkJoinPool} to inject
+     */
+    public XmlResponseQueueTransformer(ForkJoinPool fjp) {
+        this.fjp = fjp;
+    }
+
+    /**
+     * @param threshold the fork threshold: result lists smaller than this size will be
+     *                  processed serially; larger than this size will be processed in
+     *                  threshold-sized chunks in parallel
+     */
+    public void setThreshold(int threshold) {
+        this.threshold = threshold <= 1 ? 2 : threshold;
     }
 
     @Override
     public BinaryContent transform(SourceResponse response, Map<String, Serializable> args)
             throws CatalogTransformerException {
-
-        if (response == null) {
-            LOGGER.debug("Attempted to transform null response");
-            throw new CatalogTransformerException("Unable to transform null response");
-        }
-
-        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-
         try {
-            Thread.currentThread()
-                    .setContextClassLoader(XmlMetacardTransformer.class.getClassLoader());
+            Writer stringWriter = new StringWriter(BUFFER_SIZE);
+            stringWriter.append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n");
 
-            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            MetacardPrintWriter writer = new MetacardPrintWriter(stringWriter);
 
-            try {
-                Marshaller marshaller = CONTEXT.createMarshaller();
-
-                // TODO configure this option via Metatype DDF-2158
-                marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-
-                marshaller.setEventHandler(new DefaultValidationEventHandler());
-
-                try {
-                    marshaller.marshal(new AdaptedSourceResponse(response), os);
-                } catch (RuntimeException e) {
-                    LOGGER.info("Failed transformation", e);
-                    throw new CatalogTransformerException("Failed Transformation", e);
-                }
-            } catch (JAXBException e) {
-                LOGGER.info("Failed JAXB transformation", e);
-                throw new CatalogTransformerException("Failed JAXB Transformation", e);
+            writer.startNode("metacards");
+            for (Map.Entry<String, String> nsRow : NAMESPACE_MAP.entrySet()) {
+                writer.addAttribute(nsRow.getKey(), nsRow.getValue());
             }
 
-            ByteArrayInputStream bais = new ByteArrayInputStream(os.toByteArray());
+            if (response.getResults() != null && !response.getResults().isEmpty()) {
+                StringWriter metacardContent = fjp
+                        .invoke(new MetacardForkTask(ImmutableList.copyOf(response.getResults()),
+                                fjp, threshold));
+
+                writer.setRawValue(metacardContent.getBuffer().toString());
+            }
+
+            writer.endNode(); // metacards
+
+            ByteArrayInputStream bais = new ByteArrayInputStream(
+                    stringWriter.toString().getBytes());
 
             return new BinaryContentImpl(bais, MIME_TYPE);
-
-        } finally {
-            Thread.currentThread().setContextClassLoader(tccl);
+        } catch (Exception e) {
+            LOGGER.info("Failed Query response transformation", e);
+            throw new CatalogTransformerException("Failed Query response transformation");
         }
-
     }
-
 }

--- a/transformer/catalog-transformer-xml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/transformer/catalog-transformer-xml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,41 +12,50 @@
  **/ -->
 
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-		>
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
 
-	<service interface="ddf.catalog.transform.InputTransformer">
-		<service-properties>
-			<entry key="id" value="xml"/>
-			<entry key="mime-type" value="text/xml"/>
+    <service interface="ddf.catalog.transform.InputTransformer">
+        <service-properties>
+            <entry key="id" value="xml"/>
+            <entry key="mime-type" value="text/xml"/>
             <entry key="schema" value="urn:catalog:metacard"/>
-		</service-properties>
-		<bean class="ddf.catalog.transformer.xml.XmlInputTransformer">
-			<property name="metacardTypes">
-				<reference-list interface="ddf.catalog.data.MetacardType" availability="optional"/>
-			</property>
-		</bean>
-	</service>
+        </service-properties>
+        <bean class="ddf.catalog.transformer.xml.XmlInputTransformer">
+            <property name="metacardTypes">
+                <reference-list interface="ddf.catalog.data.MetacardType" availability="optional"/>
+            </property>
+        </bean>
+    </service>
 
-	<service interface="ddf.catalog.transform.MetacardTransformer">
-		<service-properties>
-			<entry key="id" value="xml"/>
-			<entry key="mime-type" value="text/xml"/>
-			<entry key="title" value="View as XML..."/>
+    <service interface="ddf.catalog.transform.MetacardTransformer">
+        <service-properties>
+            <entry key="id" value="xml"/>
+            <entry key="mime-type" value="text/xml"/>
+            <entry key="title" value="View as XML..."/>
             <!-- deprecated -->
             <entry key="shortname" value="xml"/>
             <entry key="schema" value="urn:catalog:metacard"/>
-		</service-properties>
-		<bean class="ddf.catalog.transformer.xml.XmlMetacardTransformer"/>
-	</service>
+        </service-properties>
+        <bean class="ddf.catalog.transformer.xml.XmlMetacardTransformer"/>
+    </service>
 
-	<service interface="ddf.catalog.transform.QueryResponseTransformer">
-		<service-properties>
-			<entry key="id" value="xml"/>
-			<entry key="shortname" value="xml"/>
-			<entry key="mime-type" value="text/xml"/>
+    <bean id="xmlResponseQueueTransformer" class="ddf.catalog.transformer.xml.XmlResponseQueueTransformer">
+        <cm:managed-properties
+                persistent-id="ddf.catalog.transformer.xml.XmlResponseQueueTransformer"
+                update-strategy="container-managed"/>
+        <argument ref="fjp"/>
+        <property name="threshold" value="50"/>
+    </bean>
+
+    <bean id="fjp" class="java.util.concurrent.ForkJoinPool"/>
+
+    <service ref="xmlResponseQueueTransformer" interface="ddf.catalog.transform.QueryResponseTransformer">
+        <service-properties>
+            <entry key="id" value="xml"/>
+            <entry key="shortname" value="xml"/>
+            <entry key="mime-type" value="text/xml"/>
             <entry key="schema" value="urn:catalog:metacard"/>
-		</service-properties>
-		<bean class="ddf.catalog.transformer.xml.XmlResponseQueueTransformer"/>
-	</service>
-	
+        </service-properties>
+    </service>
+
 </blueprint>

--- a/transformer/catalog-transformer-xml/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/transformer/catalog-transformer-xml/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Xml Query Transformer"
+         description="Xml Response Queue Transformer"
+         id="ddf.catalog.transformer.xml.XmlResponseQueueTransformer">
+        <AD name="Parallel Marhsalling Threshold" id="threshold" required="true" type="Integer"
+            default="50"
+            min="2"
+            description="Response size threshold above which marshalling is run in parallel"/>
+    </OCD>
+
+    <Designate
+            pid="ddf.catalog.transformer.xml.XmlResponseQueueTransformer">
+        <Object
+                ocdref="ddf.catalog.transformer.xml.XmlResponseQueueTransformer"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/transformer/catalog-transformer-xml/src/test/jmeter/XMLTransformerPerformance.jmx
+++ b/transformer/catalog-transformer-xml/src/test/jmeter/XMLTransformerPerformance.jmx
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="2.8" jmeter="2.13 r1665067">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="XML Transformer Real World Test" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
+        <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+          <collectionProp name="Arguments.arguments"/>
+        </elementProp>
+        <stringProp name="HTTPSampler.domain">localhost</stringProp>
+        <stringProp name="HTTPSampler.port">8993</stringProp>
+        <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+        <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        <stringProp name="HTTPSampler.protocol">https</stringProp>
+        <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+        <stringProp name="HTTPSampler.path">/services/catalog/query</stringProp>
+        <stringProp name="HTTPSampler.concurrentPool">4</stringProp>
+      </ConfigTestElement>
+      <hashTree/>
+      <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>false</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <threadCounts>true</threadCounts>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="25 users &amp; 10 results" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">25</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">25</stringProp>
+        <longProp name="ThreadGroup.start_time">1433869241000</longProp>
+        <longProp name="ThreadGroup.end_time">1433869241000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Query" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="q" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">*</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">q</stringProp>
+              </elementProp>
+              <elementProp name="format" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">xml</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">format</stringProp>
+              </elementProp>
+              <elementProp name="mr" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">10</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">mr</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain"></stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path"></stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="3 Users &amp; 100 results" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">3</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">3</stringProp>
+        <longProp name="ThreadGroup.start_time">1433869241000</longProp>
+        <longProp name="ThreadGroup.end_time">1433869241000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Query" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="q" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">*</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">q</stringProp>
+              </elementProp>
+              <elementProp name="format" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">xml</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">format</stringProp>
+              </elementProp>
+              <elementProp name="mr" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">100</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">mr</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain"></stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path"></stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="1 User &amp; 1000 results" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <longProp name="ThreadGroup.start_time">1433869241000</longProp>
+        <longProp name="ThreadGroup.end_time">1433869241000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Query" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="q" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">*</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">q</stringProp>
+              </elementProp>
+              <elementProp name="format" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">xml</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">format</stringProp>
+              </elementProp>
+              <elementProp name="mr" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">1000</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">mr</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain"></stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path"></stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+      </hashTree>
+      <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>false</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <threadCounts>true</threadCounts>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/transformer/catalog-transformer-xml/src/test/jmeter/jmeter.properties
+++ b/transformer/catalog-transformer-xml/src/test/jmeter/jmeter.properties
@@ -1,0 +1,1 @@
+jmeter.save.saveservice.thread_counts=true


### PR DESCRIPTION
Updates `XmlResponseQueueTransformer` to use XStream instead of JAXB and incorporates a ForkJoinPool with default serial threshold of 50.

### Review notes:
+ I would strongly recommend that you not try to diff the new version of `XmlResponseQueueTransformer` against the old, but look at it as a completely new file.
+ If anyone has any suggestions on more/better unit tests, I'll be glad to hear them.
+ A second pull request will go up sometime later this week in the ddf repo with integration test additions.

### Reviewers:

+ @kcwire
+ @millerw8
+ @pklinef
+ @wmcnalli
+ @jlcsmith
+ @beyelerb
+ @emanns95
+ @jrnorth

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-catalog/99)
<!-- Reviewable:end -->
