### PR TITLE
DDF-1317 Renaming a catalog source through the admin ui creates a dupe

### DIFF
--- a/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
+++ b/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
@@ -132,6 +132,7 @@ define(function (require) {
         parseServiceModel: function() {
             var resModel = this;
             var collection = resModel.get('collection');
+            collection.reset();
             if(this.model.get("value")) {
                 this.model.get("value").each(function(service) {
                     if(!_.isEmpty(service.get("configurations"))) {

--- a/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ModalSource.view.js
+++ b/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ModalSource.view.js
@@ -162,7 +162,10 @@ function (ich,Marionette,Backbone,ConfigurationEdit,Service,Utils,wreqr,_,$,moda
                 model.save().then(function() {
                     var needsRefresh = true;
                     var existingSource = view.parentModel.get('collection').find(function(item) {
-                        return item.get('name') === view.getId(model);
+                        return (item &&
+                                item.attributes &&
+                                item.attributes.currentConfiguration &&
+                                item.attributes.currentConfiguration.id === view.getPID(model));
                     });
                     if (existingSource) {
                         var toDisable = existingSource.get('currentConfiguration');
@@ -285,6 +288,9 @@ function (ich,Marionette,Backbone,ConfigurationEdit,Service,Utils,wreqr,_,$,moda
         getId: function(config) {
             var properties = config.get('properties');
             return properties.get('shortname') || properties.get('id');
+        },
+        getPID: function(config) {
+            return config.id;
         },
         closeAndUnbind: function() {
             this.modelBinder.unbind();

--- a/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ModalSource.view.js
+++ b/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ModalSource.view.js
@@ -163,7 +163,7 @@ function (ich,Marionette,Backbone,ConfigurationEdit,Service,Utils,wreqr,_,$,moda
                     var needsRefresh = true;
                     var existingSource = view.parentModel.get('collection').find(function(item) {
                         var config = item.get('currentConfiguration');
-                        return (config && config.id === view.getPID(model));
+                        return (config && config.id === model.id);
                     });
                     if (existingSource) {
                         var toDisable = existingSource.get('currentConfiguration');
@@ -286,9 +286,6 @@ function (ich,Marionette,Backbone,ConfigurationEdit,Service,Utils,wreqr,_,$,moda
         getId: function(config) {
             var properties = config.get('properties');
             return properties.get('shortname') || properties.get('id');
-        },
-        getPID: function(config) {
-            return config.id;
         },
         closeAndUnbind: function() {
             this.modelBinder.unbind();

--- a/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ModalSource.view.js
+++ b/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ModalSource.view.js
@@ -162,10 +162,8 @@ function (ich,Marionette,Backbone,ConfigurationEdit,Service,Utils,wreqr,_,$,moda
                 model.save().then(function() {
                     var needsRefresh = true;
                     var existingSource = view.parentModel.get('collection').find(function(item) {
-                        return (item &&
-                                item.attributes &&
-                                item.attributes.currentConfiguration &&
-                                item.attributes.currentConfiguration.id === view.getPID(model));
+                        var config = item.get('currentConfiguration');
+                        return (config && config.id === view.getPID(model));
                     });
                     if (existingSource) {
                         var toDisable = existingSource.get('currentConfiguration');


### PR DESCRIPTION
In reality, all edits through the UI create new, modified, active configurations and move the old configuration to the disabled state; however, name changes weren't behaving that way. Now, equality of old and new configurations will not be validated against name but against PID.

@pklinef 
@tbatieConnexta 
@djblue 
@rzwiefel
@kcwire
@roelens8
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-catalog/109)
<!-- Reviewable:end -->
