### PR TITLE
DDF-1340 Fixes bundling issue causing integration test failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
         <antlr.version>4.3</antlr.version>
         <jaxb.annotate.plugin.version>0.6.0</jaxb.annotate.plugin.version>
         <jaxb.visitor.plugin.version>1.13</jaxb.visitor.plugin.version>
-        <xmlpull.bundle.version>1.1.3.1_2</xmlpull.bundle.version>
         <catalog.joda.time.version>2.2</catalog.joda.time.version>
     </properties>
 

--- a/spatial/spatial-app/src/main/resources/features.xml
+++ b/spatial/spatial-app/src/main/resources/features.xml
@@ -40,8 +40,6 @@
              description="Web Feature Service (WFS).">
         <bundle>mvn:org.codice.ddf.spatial/spatial-ogc-urlresourcereader/${project.version}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/${cxf.xpp3.bundle.version}</bundle>
-        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlpull/${xmlpull.bundle.version}
-        </bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstream.bundle.version}
         </bundle>
         <bundle>mvn:org.codice.ddf.spatial/spatial-wfs-api/${project.version}</bundle>

--- a/transformer/catalog-transformer-xml/pom.xml
+++ b/transformer/catalog-transformer-xml/pom.xml
@@ -118,8 +118,8 @@
                         </Private-Package>
                         <Export-Package/>
                         <Import-Package>
-                            *,
-                            org.joda.time;version="[1.6.0,3.0.0)"
+                            org.joda.time;version="[1.6.0,3.0.0)",
+                            *
                         </Import-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
XmlPull has a terrible, overlapping pair of bundles. Anywhere that actually needs an implementation of XmlPull's parser needs the xpp3 servicemix bundle, not the xmlpull bundle.

@kcwire 
@pklinef 
@tbatieConnexta 
@jckilmer
@rzwiefel
@roelens8

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-catalog/116)
<!-- Reviewable:end -->
