### PR TITLE
DDF-1353 Intermittent test failure caused by missing mock methods.

### DIFF
--- a/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
+++ b/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
@@ -122,11 +122,7 @@ public class ReliableResourceDownloadManager {
 
         try {
             resourceResponse = retriever.retrieveResource();
-        } catch (ResourceNotFoundException e) {
-            throw new DownloadException("Cannot download resource", e);
-        } catch (ResourceNotSupportedException e) {
-            throw new DownloadException("Cannot download resource", e);
-        } catch (IOException e) {
+        } catch (ResourceNotFoundException | ResourceNotSupportedException | IOException e) {
             throw new DownloadException("Cannot download resource", e);
         }
 

--- a/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
+++ b/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
@@ -255,16 +255,8 @@ public class ReliableResourceDownloader implements Runnable {
                             downloaderConfig.getMonitorPeriodMS());
                     downloadStarted.set(Boolean.TRUE);
                     reliableResourceStatus = downloadFuture.get();
-                } catch (InterruptedException e) {
-                    LOGGER.error("InterruptedException - Unable to store product file {}", filePath,
-                            e);
-                    reliableResourceStatus = reliableResourceCallable.getReliableResourceStatus();
-                } catch (ExecutionException e) {
-                    LOGGER.error("ExecutionException - Unable to store product file {}", filePath,
-                            e);
-                    reliableResourceStatus = reliableResourceCallable.getReliableResourceStatus();
-                } catch (CancellationException e) {
-                    LOGGER.error("CancellationException - Unable to store product file {}",
+                } catch (InterruptedException | CancellationException | ExecutionException e) {
+                    LOGGER.error("{} - Unable to store product file {}", e.getClass().getSimpleName(),
                             filePath, e);
                     reliableResourceStatus = reliableResourceCallable.getReliableResourceStatus();
                 }
@@ -505,11 +497,7 @@ public class ReliableResourceDownloader implements Runnable {
 
             // So that Callable can account for bytes read in previous download attempt(s)
             reliableResourceCallable.setBytesRead(bytesRead);
-        } catch (ResourceNotFoundException e) {
-            LOGGER.warn("Unable to re-retrieve product; cannot download product file {}", filePath);
-        } catch (ResourceNotSupportedException e) {
-            LOGGER.warn("Unable to re-retrieve product; cannot download product file {}", filePath);
-        } catch (IOException e) {
+        } catch (ResourceNotFoundException | ResourceNotSupportedException | IOException e) {
             LOGGER.warn("Unable to re-retrieve product; cannot download product file {}", filePath);
         }
 

--- a/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ResourceRetrievalMonitor.java
+++ b/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ResourceRetrievalMonitor.java
@@ -37,7 +37,7 @@ public class ResourceRetrievalMonitor extends TimerTask {
 
     private Future<?> future;
 
-    private ReliableResourceCallable reliableResourceCallable;
+    private final ReliableResourceCallable reliableResourceCallable;
 
     private long monitorPeriod;
 

--- a/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ResourceRetrievalMonitor.java
+++ b/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ResourceRetrievalMonitor.java
@@ -35,19 +35,19 @@ public class ResourceRetrievalMonitor extends TimerTask {
 
     private long previousBytesRead = 0;
 
-    private Future<?> future;
+    private final Future<?> future;
 
     private final ReliableResourceCallable reliableResourceCallable;
 
-    private long monitorPeriod;
+    private final long monitorPeriod;
 
-    private DownloadsStatusEventPublisher eventPublisher;
+    private final DownloadsStatusEventPublisher eventPublisher;
 
-    private ResourceResponse resourceResponse;
+    private final ResourceResponse resourceResponse;
 
-    private Metacard metacard;
+    private final Metacard metacard;
 
-    private String downloadIdentifier;
+    private final String downloadIdentifier;
 
     /**
      * @param future the @Future that started the @ReliableResourceCallable doing the resource download

--- a/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ProductDownloadClient.java
+++ b/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ProductDownloadClient.java
@@ -88,21 +88,8 @@ public class ProductDownloadClient implements Callable<ByteArrayOutputStream> {
                     break;
                 } else if (simulateCacheFileExceptionChunkCount == chunkCount) {
                     LOGGER.debug("got 1");
-                    // FileOutputStream cacheFileOutputStream = downloadMgr.getFileOutputStream();
-                    // try {
-                    // LOGGER.debug("Closing cacheFileOutputStream to simulate CACHED_FILE_OUTPUT_STREAM_EXCEPTION");
-                    // cacheFileOutputStream.close();
-                    // } catch (IOException e) {
-                    // }
                 } else if (simulateFbosExceptionChunkCount == chunkCount) {
                     LOGGER.debug("got 2");
-                    // FileBackedOutputStream fbos = downloadMgr.getFileBackedOutputStream();
-                    // try {
-                    // LOGGER.debug("Closing FileBackedOutputStream to simulate CLIENT_OUTPUT_STREAM_EXCEPTION");
-                    // fbos.close();
-                    // } catch (IOException e) {
-                    // LOGGER.debug("Could not close FileBackedOutputStream");
-                    // }
                 }
             }
             IOUtils.closeQuietly(is);

--- a/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
+++ b/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import javax.activation.MimeType;
 import javax.activation.MimeTypeParseException;
@@ -79,7 +80,6 @@ public class ReliableResourceDownloadManagerTest {
     public static final int MAX_RETRY_ATTEMPTS = 3;
 
     public static final int DELAY_BETWEEN_ATTEMPTS = 5;
-
 
     public static final int MONITOR_PERIOD = 5;
 
@@ -290,7 +290,7 @@ public class ReliableResourceDownloadManagerTest {
 
     /**
      * Verifies that if client is reading from @ReliableResourceInputStream slower than
-     * @ReliableResourceCallable is reading from product InputStream and writing to FileBackedOutputStream,
+     * {@link ReliableResourceCallable} is reading from product InputStream and writing to FileBackedOutputStream,
      * that complete product is still successfully downloaded by the client.
      * (This will be the case with CXF and @ReliableResourceCallable)
      *
@@ -468,7 +468,7 @@ public class ReliableResourceDownloadManagerTest {
     public void testClientCancelProductDownloadCachingStops() throws Exception {
 
         mis = new MockInputStream(productInputFilename, true);
-        mis.setReadDelay(MONITOR_PERIOD - 2);
+        mis.setReadDelay(MONITOR_PERIOD - 2, TimeUnit.MILLISECONDS);
 
         Metacard metacard = getMockMetacard(EXPECTED_METACARD_ID, EXPECTED_METACARD_SOURCE_ID);
         resourceResponse = getMockResourceResponse();
@@ -575,7 +575,7 @@ public class ReliableResourceDownloadManagerTest {
         // download manager is writing to, simulating a cache file exception during
         // the product download
         mis = new MockInputStream(productInputFilename, true);
-        mis.setReadDelay(MONITOR_PERIOD - 2);
+        mis.setReadDelay(MONITOR_PERIOD - 2, TimeUnit.MILLISECONDS);
 
         Metacard metacard = getMockMetacard(EXPECTED_METACARD_ID, EXPECTED_METACARD_SOURCE_ID);
         resourceResponse = getMockResourceResponse();
@@ -755,7 +755,7 @@ public class ReliableResourceDownloadManagerTest {
                 invocationCount++;
                 if (readSlow) {
                     mis = new MockInputStream(productInputFilename, true);
-                    mis.setReadDelay(MONITOR_PERIOD - 2);
+                    mis.setReadDelay(MONITOR_PERIOD - 2, TimeUnit.MILLISECONDS);
                 } else {
                     mis = new MockInputStream(productInputFilename);
                 }
@@ -769,10 +769,10 @@ public class ReliableResourceDownloadManagerTest {
                 } else if (retryType == RetryType.TIMEOUT_EXCEPTION) {
                     if (invocationCount == 1) {
                         mis.setInvocationCountToTimeout(3);
-                        mis.setReadDelay(MONITOR_PERIOD * 2);
+                        mis.setReadDelay(MONITOR_PERIOD * 2, TimeUnit.SECONDS);
                     } else {
                         mis.setInvocationCountToTimeout(-1);
-                        mis.setReadDelay(0);
+                        mis.setReadDelay(0, TimeUnit.MILLISECONDS);
                     }
                 } else if (retryType == RetryType.NETWORK_CONNECTION_UP_AND_DOWN) {
                     mis.setInvocationCountToThrowIOException(2);
@@ -829,7 +829,7 @@ public class ReliableResourceDownloadManagerTest {
                 invocationCount++;
                 if (readSlow) {
                     mis = new MockInputStream(productInputFilename, true);
-                    mis.setReadDelay(MONITOR_PERIOD - 2);
+                    mis.setReadDelay(MONITOR_PERIOD - 2, TimeUnit.MILLISECONDS);
                 } else {
                     mis = new MockInputStream(productInputFilename);
                 }
@@ -849,10 +849,10 @@ public class ReliableResourceDownloadManagerTest {
                 } else if (retryType == RetryType.TIMEOUT_EXCEPTION) {
                     if (invocationCount == 1) {
                         mis.setInvocationCountToTimeout(3);
-                        mis.setReadDelay(MONITOR_PERIOD * 2);
+                        mis.setReadDelay(MONITOR_PERIOD * 2, TimeUnit.SECONDS);
                     } else {
                         mis.setInvocationCountToTimeout(-1);
-                        mis.setReadDelay(0);
+                        mis.setReadDelay(0, TimeUnit.MILLISECONDS);
                     }
                 } else if (retryType == RetryType.NETWORK_CONNECTION_UP_AND_DOWN) {
                     mis.setInvocationCountToThrowIOException(2);
@@ -879,9 +879,11 @@ public class ReliableResourceDownloadManagerTest {
                 reset(resourceResponse);
                 when(resourceResponse.getRequest()).thenReturn(resourceRequest);
                 when(resourceResponse.getResource()).thenReturn(resource);
-                Map<String, Serializable> responseProperties = new HashMap<String, Serializable>();
+                Map<String, Serializable> responseProperties = new HashMap<>();
                 responseProperties.put("BytesSkipped", true);
                 when(resourceResponse.getProperties()).thenReturn(responseProperties);
+                when(resourceResponse.containsPropertyName("BytesSkipped")).thenReturn(true);
+                when(resourceResponse.getPropertyValue("BytesSkipped")).thenReturn(true);
 
                 return resourceResponse;
             }


### PR DESCRIPTION
This problem only seems to have manifested itself in our CI environments, presumably because their resource constraints caused the test to run slowly enough to trigger the `ReliableResourceDownloadManager` to actually attempt a retry, hitting the problem skipping bytes. By increasing the lag to 10 seconds, I was able to reliably reproduce the error locally.

The questions I now have are...

+ Can we accept a 30-second test at all
+ ...or drop to a smaller period of sleep that will still test the underlying functionality
+ ...or drop it back to a negligible sleep and add comments so it can be manually bumped?
+ I tested the other non-ignored tests in the class with seconds-long sleeps instead of milliseconds and they worked, but I left them all at millis for now; should I change that?

I need a hero on this ticket...@rzwiefel, could you do that please?

@lessarderic 
@pklinef 
@tbatieConnexta 
@jckilmer
@rzwiefel
@roelens8

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-catalog/129)
<!-- Reviewable:end -->
