### PR TITLE
DDF-1354: Removed distributionManagement from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,13 +65,6 @@
         <catalog.joda.time.version>2.2</catalog.joda.time.version>
     </properties>
 
-    <distributionManagement>
-        <site>
-            <id>ddf-site</id>
-            <url>${ddf.site.repo}/ddf-catalog/${project.version}</url>
-        </site>
-    </distributionManagement>
-
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
 -A distributionManagement section was overriding the location of the
site-deploy on the bamboo build server. It was removed from other repos
in an earlier PR but this one must have been missed. I removed it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-catalog/130)
<!-- Reviewable:end -->
